### PR TITLE
Fix bug from improper handling of raketask string

### DIFF
--- a/lib/postamt/railtie.rb
+++ b/lib/postamt/railtie.rb
@@ -12,7 +12,10 @@ module Postamt
         # We mustn't hook into AR when db:migrate or db:test:load_schema
         # run, but user-defined Rake tasks still need us
         task_names = []
-        tasks_to_examine = Rake.application.top_level_tasks.map{ |task_name| Rake.application[task_name] }
+        tasks_to_examine = Rake.application.top_level_tasks.map{ |task_string|
+          task_name, task_args = Rake.application.parse_task_string(task_string)
+          Rake.application[task_name]
+        }
         until tasks_to_examine.empty?
           task = tasks_to_examine.pop
           task_names << task.name


### PR DESCRIPTION
How to reproduce

1: put any raketask with arguments.

`lib/tasks/sometask.rake`
```ruby
task :sometask, ['spam', 'ham'] => :environment do |task, args|
    p args[:spam]
end
```

2: invoke raketask with arguments.

`bundle exec rake sometask\[egg\]`
or
`bundle exec rake "sometask[egg]"`